### PR TITLE
fixa a imagem do postgres na versão 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:16
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
## O que mudou
Pinamos a imagem do Postgres na versão 16 no `docker-compose.yml`.

## Solução proposta
Trocar `image: postgres` por `image: postgres:16` no serviço `db`. A tag `latest` agora resolve para Postgres 18, que mudou o layout dos dados em disco e recusa subir sobre o volume `./tmp/db` existente.

## Como testar
1. Suba a stack: ```docker compose up -d```
2. Verifique que o container `db` ficou `Up`: ```docker compose ps```
3. Rode `db:prepare` no web: ```docker compose exec web bundle exec rails db:prepare```

## Riscos
Nenhum - Postgres 16 é a mesma versão que o projeto já usava implicitamente.

## Impactos negativos previstos
Nenhum impacto previsto.

## Instruções para deploy
Nenhuma instrução adicional.

## Instruções para retorno
Rollback padrão desse PR.