### PR TITLE
adiciona índices nas colunas de filtro de movies

### DIFF
--- a/db/migrate/20260528120000_add_indices_to_movies.rb
+++ b/db/migrate/20260528120000_add_indices_to_movies.rb
@@ -1,0 +1,9 @@
+class AddIndicesToMovies < ActiveRecord::Migration[6.1]
+  def change
+    add_index :movies, :title, unique: true
+    add_index :movies, :year
+    add_index :movies, :genre
+    add_index :movies, :country
+    add_index :movies, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,18 @@
-ActiveRecord::Schema.define(version: 2024_10_25_015945) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2026_05_28_120000) do
+
+  # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -20,5 +34,11 @@ ActiveRecord::Schema.define(version: 2024_10_25_015945) do
     t.text "description"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["country"], name: "index_movies_on_country"
+    t.index ["genre"], name: "index_movies_on_genre"
+    t.index ["published_at"], name: "index_movies_on_published_at"
+    t.index ["title"], name: "index_movies_on_title", unique: true
+    t.index ["year"], name: "index_movies_on_year"
   end
+
 end


### PR DESCRIPTION
## O que mudou
Adiciona índices B-tree em `year`, `genre`, `country`, `published_at` e um índice `UNIQUE` em `title`.

## Solução proposta
Nova migration `AddIndicesToMovies` cobrindo as colunas usadas pelos filtros Ransack do `index` e tornando a deduplicação de títulos garantida no nível do banco (a validação `uniqueness:` no modelo sozinha é suscetível a race condition).

## Como testar
1. Suba o projeto: ```docker compose up -d```
2. Rode a migration: ```docker compose exec web bundle exec rails db:migrate```
3. Rode os testes: ```docker compose exec web bundle exec rspec```
4. (Opcional) verifique o plano de consulta: ```docker compose exec web bundle exec rails runner "puts Movie.where(year: 2020).explain"```

## Riscos
Pequeno aumento de tempo nas escritas e no tamanho do banco - irrelevante para o volume do desafio (~8k filmes).

## Impactos negativos previstos
Nenhum impacto previsto.

## Instruções para deploy
Rodar `db:migrate` no deploy.

## Instruções para retorno
Rollback padrão desse PR (a migration tem rollback automático via `change`).