### PR TITLE
refatora a importação para fazer stream do CSV com headers nomeados

### DIFF
--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::MoviesController < ApplicationController
 
   def create
     uploaded_file = params[:file]
-    import = MovieImport.create(file_name: uploaded_file.original_filename, status: 1)
+    import = MovieImport.create(file_name: uploaded_file.original_filename, status: :processing)
 
     if import.import_movies(uploaded_file)
       render json: {message: I18n.t("messages.import.success")}, status: :created

--- a/app/models/movie_import.rb
+++ b/app/models/movie_import.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 class MovieImport < ApplicationRecord
   has_many :movies, dependent: :destroy
 
@@ -7,45 +9,49 @@ class MovieImport < ApplicationRecord
   enum status: {failed: 0, processing: 1, completed: 2, invalid_file: 3}
 
   def import_movies(file)
-    return update_failed_import(I18n.t("messages.import.invalid_format"), 3) unless valid_csv_file?(file)
-    return update_failed_import(I18n.t("messages.import.empty_file"), 3) unless empty_file?(file)
+    return mark_invalid_file(I18n.t("messages.import.invalid_format")) unless valid_csv?(file)
+    return mark_invalid_file(I18n.t("messages.import.empty_file")) if blank_csv?(file)
 
-    begin
-      movies_data = create_movies(file)
-      update(status: 2, movies_count: movies_data.size) if movies_data.any?
-    rescue ActiveRecord::RecordInvalid => e
-      update_failed_import(I18n.t("messages.import.create_error", error_message: e), 0)
-    end
+    process(file)
+  rescue ActiveRecord::RecordInvalid => e
+    update!(
+      status: :failed,
+      movies_count: 0,
+      error_message: I18n.t("messages.import.create_error", error_message: e)
+    )
+    false
   end
 
   private
 
-  def update_failed_import(message, status)
-    update(status: status, movies_count: 0, error_message: message)
-    false
-  end
-
-  def valid_csv_file?(file)
+  def valid_csv?(file)
     file && file.content_type == "text/csv"
   end
 
-  def empty_file?(file)
-    require "csv"
-    CSV.readlines(file).any?
+  def blank_csv?(file)
+    CSV.foreach(file.path, headers: true).first.nil?
   end
 
-  def create_movies(file)
-    require "csv"
-    CSV.readlines(file).map.with_index do |row, index|
-      next if index == 0
-      Movie.create!(
-        genre: row[1],
-        title: row[2],
-        country: row[5],
-        published_at: row[6],
-        year: row[7],
-        description: row[11]
-      )
-    end.compact
+  def process(file)
+    count = 0
+    Movie.transaction do
+      CSV.foreach(file.path, headers: true) do |row|
+        Movie.create!(
+          genre: row["type"],
+          title: row["title"],
+          country: row["country"],
+          published_at: row["date_added"],
+          year: row["release_year"],
+          description: row["description"]
+        )
+        count += 1
+      end
+    end
+    update!(status: :completed, movies_count: count)
+  end
+
+  def mark_invalid_file(message)
+    update!(status: :invalid_file, movies_count: 0, error_message: message)
+    false
   end
 end


### PR DESCRIPTION
## O que mudou
Refatora `MovieImport` para fazer stream do arquivo CSV em vez de carregar tudo em memória, acessando colunas por nome.

## Solução proposta
- Substitui `CSV.readlines(file)` (carrega tudo, era chamado duas vezes) por `CSV.foreach(path, headers: true)`.
- Acesso por nome de coluna (`row["title"]`) em vez de posição mágica (`row[2]`).
- Envelopa o loop de inserts em `Movie.transaction` - se uma linha falha, rollback completo.
- Renomeia o `empty_file?` (que retornava `true` quando NÃO estava vazio) para `blank_csv?`.
- Troca os números mágicos de status (`status: 1`) pelo nome do enum (`status: :processing`).
- Promove `update` para `update!` para que falhas de save apareçam.
- Move `require "csv"` para o topo do arquivo.

## Como testar
1. Suba o projeto: ```docker compose up -d```
2. Rode os testes: ```docker compose exec web bundle exec rspec```
3. Importe um CSV válido via curl:
```sh
docker compose exec web bash -c 'curl -X POST http://localhost:3001/api/v1/movies \
  -F "file=@./spec/fixtures/valid_file.csv;type=text/csv"'
```

## Riscos
Mudança de comportamento se o cabeçalho do CSV diferir do esperado - as colunas agora são acessadas por nome (`type`, `title`, `country`, `date_added`, `release_year`, `description`).

## Impactos negativos previstos
Nenhum impacto previsto.

## Instruções para deploy
Nenhuma instrução adicional.

## Instruções para retorno
Rollback padrão desse PR.