### PR TITLE
torna a importação de CSV assíncrona com SolidQueue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.3.5"
 
 gem "rails", "~> 8.0.5"
 gem "pg", "~> 1.1"
+gem "solid_queue", "~> 1.1"
 
 gem "puma", "~> 6.4"
 gem "rswag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,12 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     ffi (1.17.0-x86_64-linux-gnu)
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -158,6 +163,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.6.1)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -285,6 +291,13 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sorbet-runtime (0.5.11611)
     spring (4.2.1)
     standard (1.41.1)
@@ -334,6 +347,7 @@ DEPENDENCIES
   ruby-lsp
   shoulda-matchers (~> 6.0)
   simplecov
+  solid_queue (~> 1.1)
   spring
   standard
   standard-rails

--- a/app/controllers/api/v1/movie_imports_controller.rb
+++ b/app/controllers/api/v1/movie_imports_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::MovieImportsController < ApplicationController
+  def show
+    import = MovieImport.find(params[:id])
+    render json: import.as_json(except: [:created_at, :updated_at]), status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: {error: I18n.t("messages.import.not_found")}, status: :not_found
+  end
+end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -1,15 +1,22 @@
+require "fileutils"
+
 class Api::V1::MoviesController < ApplicationController
   rescue_from ArgumentError, with: :invalid_param_message
 
   def create
     uploaded_file = params[:file]
-    import = MovieImport.create(file_name: uploaded_file.original_filename, status: :processing)
-
-    if import.import_movies(uploaded_file)
-      render json: {message: I18n.t("messages.import.success")}, status: :created
-    else
-      render json: {error: I18n.t("messages.import.failed", error_message: import.error_message)}, status: :unprocessable_entity
+    unless uploaded_file.respond_to?(:original_filename)
+      return render json: {error: I18n.t("messages.import.missing_file")}, status: :bad_request
     end
+
+    import = MovieImport.create!(file_name: uploaded_file.original_filename, status: :processing)
+    path = persist_upload(uploaded_file, import.id)
+    ImportMoviesJob.perform_later(import.id, path, uploaded_file.content_type)
+
+    render json: {
+      message: I18n.t("messages.import.accepted"),
+      import_id: import.id
+    }, status: :accepted
   end
 
   def index
@@ -25,6 +32,15 @@ class Api::V1::MoviesController < ApplicationController
   end
 
   private
+
+  def persist_upload(uploaded_file, id)
+    dir = Rails.root.join("tmp", "imports")
+    FileUtils.mkdir_p(dir)
+    extension = File.extname(uploaded_file.original_filename)
+    path = dir.join("#{id}#{extension}").to_s
+    File.binwrite(path, uploaded_file.read)
+    path
+  end
 
   def invalid_param_message
     render json: {error: I18n.t("messages.movies.invalid_query_params")}, status: :bad_request

--- a/app/jobs/import_movies_job.rb
+++ b/app/jobs/import_movies_job.rb
@@ -1,0 +1,9 @@
+class ImportMoviesJob < ApplicationJob
+  queue_as :default
+
+  def perform(import_id, path, content_type)
+    MovieImport.find(import_id).import_movies(path, content_type)
+  ensure
+    File.delete(path) if path && File.exist?(path)
+  end
+end

--- a/app/models/movie_import.rb
+++ b/app/models/movie_import.rb
@@ -8,11 +8,11 @@ class MovieImport < ApplicationRecord
 
   enum :status, {failed: 0, processing: 1, completed: 2, invalid_file: 3}
 
-  def import_movies(file)
-    return mark_invalid_file(I18n.t("messages.import.invalid_format")) unless valid_csv?(file)
-    return mark_invalid_file(I18n.t("messages.import.empty_file")) if blank_csv?(file)
+  def import_movies(path, content_type)
+    return mark_invalid_file(I18n.t("messages.import.invalid_format")) unless valid_csv?(content_type)
+    return mark_invalid_file(I18n.t("messages.import.empty_file")) if blank_csv?(path)
 
-    process(file)
+    process(path)
   rescue ActiveRecord::RecordInvalid => e
     update!(
       status: :failed,
@@ -24,18 +24,18 @@ class MovieImport < ApplicationRecord
 
   private
 
-  def valid_csv?(file)
-    file && file.content_type == "text/csv"
+  def valid_csv?(content_type)
+    content_type == "text/csv"
   end
 
-  def blank_csv?(file)
-    CSV.foreach(file.path, headers: true).first.nil?
+  def blank_csv?(path)
+    CSV.foreach(path, headers: true).first.nil?
   end
 
-  def process(file)
+  def process(path)
     count = 0
     Movie.transaction do
-      CSV.foreach(file.path, headers: true) do |row|
+      CSV.foreach(path, headers: true) do |row|
         Movie.create!(
           genre: row["type"],
           title: row["title"],

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,6 @@ module Myapp
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.active_job.queue_adapter = :solid_queue
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.active_job.queue_adapter = :test
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -3,10 +3,13 @@ pt-BR:
   messages:
     import:
       success: "Filmes adicionados com sucesso."
+      accepted: "Importação aceita. Use o import_id para verificar o status."
       failed: "Erro na importação. %{error_message}"
       invalid_format: "Formato de arquivo inválido. Por favor, envie um arquivo CSV."
       create_error: "Erro ao criar filmes: %{error_message}"
       empty_file: "Arquivo vazio. Por favor, insira um arquivo com dados dos filmes."
+      missing_file: "Arquivo não enviado. Por favor, anexe um arquivo CSV."
+      not_found: "Importação não encontrada."
     movies:
       not_found: "Nenhum filme encontrado"
       invalid_query_params: "Parâmetro de busca inválido"

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/movies", to: "movies#create"
       get "/movies", to: "movies#index"
+      get "/movie_imports/:id", to: "movie_imports#show"
     end
   end
 end

--- a/db/migrate/20260528130000_create_solid_queue_tables.rb
+++ b/db/migrate/20260528130000_create_solid_queue_tables.rb
@@ -1,0 +1,131 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.index [:concurrency_key, :priority, :job_id], name: "index_solid_queue_blocked_executions_for_release"
+      t.index [:expires_at, :concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index [:job_id], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint :job_id, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+      t.index [:job_id], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+      t.index [:process_id, :job_id], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint :job_id, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+      t.index [:job_id], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [:active_job_id], name: "index_solid_queue_jobs_on_active_job_id"
+      t.index [:class_name], name: "index_solid_queue_jobs_on_class_name"
+      t.index [:finished_at], name: "index_solid_queue_jobs_on_finished_at"
+      t.index [:queue_name, :finished_at], name: "index_solid_queue_jobs_for_filtering"
+      t.index [:scheduled_at, :finished_at], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false
+      t.datetime :created_at, null: false
+      t.index [:queue_name], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+      t.index [:last_heartbeat_at], name: "index_solid_queue_processes_on_last_heartbeat_at"
+      t.index [:name, :supervisor_id], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+      t.index [:supervisor_id], name: "index_solid_queue_processes_on_supervisor_id"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+      t.index [:job_id], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+      t.index [:priority, :job_id], name: "index_solid_queue_poll_all"
+      t.index [:queue_name, :priority, :job_id], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+      t.index [:job_id], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+      t.index [:task_key, :run_at], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false
+      t.text :description
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [:key], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+      t.index [:static], name: "index_solid_queue_recurring_tasks_on_static"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+      t.index [:job_id], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+      t.index [:scheduled_at, :priority, :job_id], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [:expires_at], name: "index_solid_queue_semaphores_on_expires_at"
+      t.index [:key, :value], name: "index_solid_queue_semaphores_on_key_and_value"
+      t.index [:key], name: "index_solid_queue_semaphores_on_key", unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_28_120000) do
-
+ActiveRecord::Schema[8.0].define(version: 2026_05_28_130000) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
 
   create_table "movie_imports", force: :cascade do |t|
     t.string "file_name"
     t.string "error_message"
     t.integer "status"
     t.integer "movies_count"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "movies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -32,8 +31,8 @@ ActiveRecord::Schema.define(version: 2026_05_28_120000) do
     t.string "country"
     t.date "published_at"
     t.text "description"
-    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["country"], name: "index_movies_on_country"
     t.index ["genre"], name: "index_movies_on_genre"
     t.index ["published_at"], name: "index_movies_on_published_at"
@@ -41,4 +40,131 @@ ActiveRecord::Schema.define(version: 2026_05_28_120000) do
     t.index ["year"], name: "index_movies_on_year"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,19 @@ services:
       - "3001:3001"
     depends_on:
       - db
+  worker:
+    build: .
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
+    environment:
+      - LANG=pt_BR.UTF-8
+    command: bundle exec rails solid_queue:start
+    volumes:
+      - .:/myapp
+      - gems_cache:/usr/local/bundle
+    depends_on:
+      - db
 
 volumes:
   gems_cache:

--- a/spec/models/movie_import_spec.rb
+++ b/spec/models/movie_import_spec.rb
@@ -1,31 +1,29 @@
 require "rails_helper"
 
 RSpec.describe MovieImport, type: :model do
-  include ActionDispatch::TestProcess::FixtureFile
-
-  let(:valid_file) { fixture_file_upload("spec/fixtures/valid_file.csv", "text/csv") }
-  let(:empty_file) { fixture_file_upload("spec/fixtures/empty_file.csv", "text/csv") }
-  let(:with_missing_title) { fixture_file_upload("spec/fixtures/with_missing_title.csv", "text/csv") }
-  let(:invalid_file) { fixture_file_upload("spec/fixtures/invalid_file.txt", "text/plain") }
+  let(:valid_path) { Rails.root.join("spec/fixtures/valid_file.csv").to_s }
+  let(:empty_path) { Rails.root.join("spec/fixtures/empty_file.csv").to_s }
+  let(:missing_title_path) { Rails.root.join("spec/fixtures/with_missing_title.csv").to_s }
+  let(:invalid_path) { Rails.root.join("spec/fixtures/invalid_file.txt").to_s }
 
   context "Quando o arquivo é válido" do
     it "e os dados estão corretos processa filmes e atualiza o status para completed" do
-      movie_import = MovieImport.create(file_name: valid_file.original_filename, status: 1)
+      movie_import = MovieImport.create!(file_name: "valid_file.csv", status: :processing)
 
       expect {
-        movie_import.import_movies(valid_file)
+        movie_import.import_movies(valid_path, "text/csv")
       }.to change { Movie.count }.by(131)
 
       expect(movie_import.status).to eq("completed")
       expect(movie_import.movies_count).to eq(131)
     end
 
-    it "mas tem filmes sem titulo corretos processa filmes e atualiza o status para failed" do
-      movie_import = MovieImport.create(file_name: with_missing_title.original_filename, status: 1)
+    it "mas tem filmes sem titulo processa filmes e atualiza o status para failed" do
+      movie_import = MovieImport.create!(file_name: "with_missing_title.csv", status: :processing)
       error_message = "Erro ao criar filmes: A validação falhou: Title não pode ficar em branco"
 
       expect {
-        movie_import.import_movies(with_missing_title)
+        movie_import.import_movies(missing_title_path, "text/csv")
       }.to change { Movie.count }.by(0)
 
       expect(movie_import.status).to eq("failed")
@@ -36,25 +34,23 @@ RSpec.describe MovieImport, type: :model do
 
   context "Quando o arquivo é inválido" do
     it "atualiza o status para invalid_file e retorna erro de arquivo inválido" do
-      movie_import = MovieImport.create(file_name: invalid_file.original_filename, status: 1)
+      movie_import = MovieImport.create!(file_name: "invalid_file.txt", status: :processing)
 
-      movie_import.import_movies(invalid_file)
+      movie_import.import_movies(invalid_path, "text/plain")
 
       expect(movie_import.status).to eq("invalid_file")
       expect(movie_import.error_message).to eq("Formato de arquivo inválido. Por favor, envie um arquivo CSV.")
       expect(movie_import.movies_count).to eq(0)
     end
 
-    context "Quando o arquivo é inválido" do
-      it "atualiza o status para invalid_file e retorna erro de arquivo vazio" do
-        movie_import = MovieImport.create(file_name: empty_file.original_filename, status: 1)
+    it "atualiza o status para invalid_file e retorna erro de arquivo vazio" do
+      movie_import = MovieImport.create!(file_name: "empty_file.csv", status: :processing)
 
-        movie_import.import_movies(empty_file)
+      movie_import.import_movies(empty_path, "text/csv")
 
-        expect(movie_import.status).to eq("invalid_file")
-        expect(movie_import.error_message).to eq("Arquivo vazio. Por favor, insira um arquivo com dados dos filmes.")
-        expect(movie_import.movies_count).to eq(0)
-      end
+      expect(movie_import.status).to eq("invalid_file")
+      expect(movie_import.error_message).to eq("Arquivo vazio. Por favor, insira um arquivo com dados dos filmes.")
+      expect(movie_import.movies_count).to eq(0)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,6 @@ require "simplecov"
 SimpleCov.start "rails" do
   add_filter "channels"
   add_filter "mailers"
-  add_filter "jobs"
 end
 
 ENV["RAILS_ENV"] ||= "test"
@@ -28,13 +27,15 @@ Shoulda::Matchers.configure do |config|
 end
 
 RSpec.configure do |config|
-  config.fixture_path = "#{Rails.root.join("spec/fixtures")}"
+  config.fixture_paths = [Rails.root.join("spec/fixtures").to_s]
 
   config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
+
+  config.include ActiveJob::TestHelper
 end
 
 def json_response

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Movies API", type: :request do
   let!(:hereditary) { Movie.create!(title: "Hereditary", genre: "Movie", year: 2018, country: "USA", published_at: "2018-08-01", description: "Spiced liberally with black comedy, this Bollywood drama follows the lethal love life of a woman who marries numerous men – only to find them flawed.") }
   let(:valid_csv) { Rack::Test::UploadedFile.new("spec/fixtures/valid_file.csv", "text/csv") }
   let(:missing_title_csv) { Rack::Test::UploadedFile.new("spec/fixtures/with_missing_title.csv", "text/csv") }
-  let(:invalid_format_file) { Rack::Test::UploadedFile.new("spec/fixtures/invalid_file.txt", "text/txt") }
+  let(:invalid_format_file) { Rack::Test::UploadedFile.new("spec/fixtures/invalid_file.txt", "text/plain") }
 
   path "/api/v1/movies" do
     get "Retorna uma lista de filmes cadastrados" do
@@ -21,15 +21,6 @@ RSpec.describe "Movies API", type: :request do
 
       context "Quando há filmes correspondentes ao filtro" do
         response "200", "retorna uma lista de filmes" do
-          example "application/json", :expected_response, {
-            id: "123e4567-e89b-12d3-a456-426614174000",
-            title: "Terrifier",
-            genre: "Terror",
-            year: 2016,
-            country: "Estados Unidos",
-            published_at: "15 de março de 2018",
-            description: "O filme segue uma noite de Halloween aterrorizante em que duas jovens encontram Art the Clown, um palhaço perturbador e mortal que as persegue e tortura de maneira implacável."
-          }
           schema type: :array,
             items: {
               type: :object,
@@ -37,7 +28,7 @@ RSpec.describe "Movies API", type: :request do
                 id: {type: :string, format: :uuid},
                 title: {type: :string},
                 genre: {type: :string},
-                year: {type: :integer, format: :date},
+                year: {type: :integer},
                 country: {type: :string},
                 published_at: {type: :string, format: :date},
                 description: {type: :string}
@@ -54,12 +45,9 @@ RSpec.describe "Movies API", type: :request do
 
       context "Quando filmes com o filtro especificado não são encontrados" do
         response "200", "retorna a mensagem de nenhum filme encontrado" do
-          example "application/json", :movie_not_found, {
-            message: "Nenhum filme encontrado"
-          }
           schema type: :object,
             properties: {
-              message: {type: :string, description: "Nenhum filme encontrado"}
+              message: {type: :string}
             }
 
           let(:"query[country_eq]") { "India" }
@@ -71,73 +59,127 @@ RSpec.describe "Movies API", type: :request do
 
       context "Quando um parâmetro inválido é passado no filtro" do
         response "400", description: "retorna a mensagem de parâmetro inválido" do
-          example "application/json", :invalid_params, {
-            message: "Parâmetro de busca inválido"
-          }
           schema type: :object,
             properties: {
-              message: {type: :string, description: "Parâmetro de busca inválido"}
+              error: {type: :string}
             }
 
           let(:"query[invalid_param_eq]") { "India" }
-          run_test! do |response|
+          run_test! do
             expect(json_response["error"]).to eq("Parâmetro de busca inválido")
           end
         end
       end
     end
 
-    post "Cadastra uma lista de filmes" do
+    post "Enfileira uma importação de filmes via CSV" do
       tags "Movies"
       consumes "multipart/form-data"
       produces "application/json"
-      parameter name: :file, in: :formData, type: :file, required: true, description: "recebe um arquivo CSV com os dados dos filmes e cadastra no banco"
+      parameter name: :file, in: :formData, type: :file, required: true, description: "arquivo CSV com os dados dos filmes"
 
       context "Quando um arquivo CSV válido é enviado" do
-        response "201", "e sem dados faltando cria os filmes no banco e retorna uma mensagem de sucesso" do
-          example "application/json", :movie_created, {
-            message: "Filmes adicionados com sucesso."
-          }
+        response "202", "enfileira o job e retorna o import_id" do
           schema type: :object,
             properties: {
-              message: {type: :string, description: "Filmes adicionados com sucesso."}
+              message: {type: :string},
+              import_id: {type: :integer}
             }
 
           let(:file) { valid_csv }
           run_test! do
-            expect(json_response["message"]).to eq("Filmes adicionados com sucesso.")
-          end
-        end
-
-        response "422", "mas o título dos filmes está faltando, retorna a mensagem de que a validação falhou" do
-          example "application/json", :fail_validation, {
-            message: "A validação falhou: Title não pode ficar em branco"
-          }
-          schema type: :object,
-            properties: {
-              error: {type: :string, description: "A validação falhou: Title não pode ficar em branco"}
-            }
-
-          let(:file) { missing_title_csv }
-          run_test! do
-            expect(json_response["error"]).to include("A validação falhou: Title não pode ficar em branco")
+            expect(json_response["import_id"]).to be_present
+            expect(ImportMoviesJob).to have_been_enqueued
           end
         end
       end
 
-      context "Quando um arquivo diferente é enviado" do
-        response "422", "retorna uma mensagem de erro sobre formato inválido" do
-          example "application/json", :invalid_file, {
-            error: "Erro na importação. Formato de arquivo inválido. Por favor, envie um arquivo CSV."
-          }
+      context "Quando nenhum arquivo é enviado" do
+        response "400", "retorna erro de arquivo faltante" do
           schema type: :object,
             properties: {
-              error: {type: :string, description: "Erro na importação. Formato de arquivo inválido. Por favor, envie um arquivo CSV."}
+              error: {type: :string}
             }
 
-          let(:file) { invalid_format_file }
+          let(:file) { nil }
           run_test! do
-            expect(json_response["error"]).to eq("Erro na importação. Formato de arquivo inválido. Por favor, envie um arquivo CSV.")
+            expect(json_response["error"]).to eq("Arquivo não enviado. Por favor, anexe um arquivo CSV.")
+          end
+        end
+      end
+    end
+  end
+
+  describe "POST /api/v1/movies (job execution)" do
+    it "processa o CSV após executar o job e marca como completed" do
+      post "/api/v1/movies", params: {file: valid_csv}
+      expect(response).to have_http_status(:accepted)
+      import_id = json_response["import_id"]
+
+      expect { perform_enqueued_jobs }.to change { Movie.count }.by(131)
+      expect(MovieImport.find(import_id).status).to eq("completed")
+    end
+
+    it "marca como failed quando o CSV tem registros inválidos" do
+      post "/api/v1/movies", params: {file: missing_title_csv}
+      import_id = json_response["import_id"]
+
+      perform_enqueued_jobs
+      import = MovieImport.find(import_id)
+
+      expect(import.status).to eq("failed")
+      expect(import.error_message).to include("Title não pode ficar em branco")
+    end
+
+    it "marca como invalid_file quando o conteúdo não é CSV" do
+      post "/api/v1/movies", params: {file: invalid_format_file}
+      import_id = json_response["import_id"]
+
+      perform_enqueued_jobs
+      import = MovieImport.find(import_id)
+
+      expect(import.status).to eq("invalid_file")
+      expect(import.error_message).to eq("Formato de arquivo inválido. Por favor, envie um arquivo CSV.")
+    end
+  end
+
+  path "/api/v1/movie_imports/{id}" do
+    parameter name: :id, in: :path, type: :integer, description: "ID da importação"
+
+    get "Retorna o status de uma importação" do
+      tags "Movie Imports"
+      produces "application/json"
+
+      context "Quando a importação existe" do
+        response "200", "retorna o registro" do
+          schema type: :object,
+            properties: {
+              id: {type: :integer},
+              file_name: {type: :string},
+              status: {type: :string},
+              movies_count: {type: :integer, nullable: true},
+              error_message: {type: :string, nullable: true}
+            }
+
+          let(:import) { MovieImport.create!(file_name: "valid_file.csv", status: :processing) }
+          let(:id) { import.id }
+          run_test! do
+            expect(json_response["status"]).to eq("processing")
+            expect(json_response["file_name"]).to eq("valid_file.csv")
+          end
+        end
+      end
+
+      context "Quando a importação não existe" do
+        response "404", "retorna mensagem de não encontrada" do
+          schema type: :object,
+            properties: {
+              error: {type: :string}
+            }
+
+          let(:id) { 0 }
+          run_test! do
+            expect(json_response["error"]).to eq("Importação não encontrada.")
           end
         end
       end


### PR DESCRIPTION
## O que mudou
A importação de CSV agora roda em background via SolidQueue. O `POST /api/v1/movies` retorna `202 Accepted` imediatamente com um `import_id`, e um novo endpoint `GET /api/v1/movie_imports/:id` permite consultar o status.

## Solução proposta
- `POST /api/v1/movies` persiste o upload em `tmp/imports/`, cria um `MovieImport` em `processing`, enfileira `ImportMoviesJob` e responde 202 + `import_id`.
- `ImportMoviesJob` carrega o `MovieImport`, processa o CSV e, no `ensure`, apaga o arquivo temporário.
- Novo controller `Api::V1::MovieImportsController#show` retorna `id`, `file_name`, `status`, `movies_count`, `error_message`.
- SolidQueue configurado em DB único (mesmo Postgres da aplicação). O `db/queue_schema.rb` gerado pelo install vira uma migration regular para evitar setup multi-DB.
- `config.active_job.queue_adapter = :solid_queue` em `application.rb`, sobrescrito para `:test` no ambiente de teste.
- Adiciona serviço `worker` no `docker-compose.yml` rodando `solid_queue:start`, para que a fila esteja operacional em dev sem comandos extras.

## Como testar
1. Suba a stack: ```docker compose up -d``` (sobe web + worker + db)
2. Rode as migrations: ```docker compose exec web bundle exec rails db:migrate```
3. Rode os testes: ```docker compose exec web bundle exec rspec``` (20/20)
4. Faça uma importação:
```sh
docker compose exec web bash -c 'curl -i -X POST http://localhost:3001/api/v1/movies \
  -F "file=@./spec/fixtures/valid_file.csv;type=text/csv"'
```
5. Consulte o status com o `import_id` retornado:
```sh
docker compose exec web bash -c 'curl -i http://localhost:3001/api/v1/movie_imports/<id>'
```

## Riscos
- Worker precisa estar rodando para a importação progredir. O `docker compose up` já sobe o serviço `worker`, mas em produção precisa de processo dedicado.
- Arquivo de upload fica em `tmp/imports/` até o job rodar - em caso de crash do worker antes do `ensure`, pode sobrar lixo.

## Impactos negativos previstos
Mais um processo (worker) consumindo recursos no docker.

## Instruções para deploy
1. Rodar `db:migrate` (cria tabelas SolidQueue).
2. Subir o processo de worker (`bin/jobs` ou `rails solid_queue:start`) em paralelo ao web.

## Instruções para retorno
Rollback padrão desse PR - a migration `CreateSolidQueueTables` tem rollback automático.