### PR TITLE
adiciona CI no github actions com rspec, brakeman e standardrb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  rspec:
+    name: RSpec
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_HOST: localhost
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: password
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Prepare DB
+        run: bundle exec rails db:prepare
+      - name: Run RSpec
+        run: bundle exec rspec
+
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run Brakeman
+        run: bundle exec brakeman --no-pager --exit-on-warn
+
+  standardrb:
+    name: StandardRB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run StandardRB
+        run: bundle exec standardrb

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 group :development, :test do
   gem "standard"
   gem "standard-rails"
+  gem "brakeman", require: false
   gem "pry-byebug"
   gem "rspec-rails", "~> 7.1"
   gem "ruby-lsp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    brakeman (8.0.4)
+      racc
     builder (3.3.0)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -335,6 +337,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  brakeman
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -34,7 +34,7 @@ class Api::V1::MoviesController < ApplicationController
   private
 
   def persist_upload(uploaded_file, id)
-    dir = Rails.root.join("tmp", "imports")
+    dir = Rails.root.join("tmp/imports")
     FileUtils.mkdir_p(dir)
     extension = File.extname(uploaded_file.original_filename)
     path = dir.join("#{id}#{extension}").to_s

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,9 +1,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: db
-  username: postgres
-  password: password
+  host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
   pool: 5
 
 development:

--- a/db/migrate/20241024184247_add_default_to_created_at_and_updated_at.rb
+++ b/db/migrate/20241024184247_add_default_to_created_at_and_updated_at.rb
@@ -1,6 +1,6 @@
 class AddDefaultToCreatedAtAndUpdatedAt < ActiveRecord::Migration[6.1]
   def change
-    change_column_default :movies, :created_at, -> { "CURRENT_TIMESTAMP" }
-    change_column_default :movies, :updated_at, -> { "CURRENT_TIMESTAMP" }
+    change_column_default :movies, :created_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
+    change_column_default :movies, :updated_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.configure do |config|
-  config.openapi_root = Rails.root.join('swagger').to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
   config.openapi_specs = {
-    'v1/swagger.yaml' => {
-      openapi: '3.0.1',
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
       info: {
-        title: 'API V1',
-        version: 'v1'
+        title: "API V1",
+        version: "v1"
       },
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: "https://{defaultHost}",
           variables: {
             defaultHost: {
-              default: 'www.example.com'
+              default: "www.example.com"
             }
           }
         }


### PR DESCRIPTION
## O que mudou
Adiciona um pipeline de CI no GitHub Actions e roda lint (standardrb) + scan de segurança (brakeman) localmente também.

## Solução proposta
- `.github/workflows/ci.yml` com três jobs paralelos:
  - `rspec`: sobe um service `postgres:16`, roda `db:prepare` e `bundle exec rspec`.
  - `brakeman`: roda `bundle exec brakeman --no-pager --exit-on-warn` (falha o build em qualquer warning).
  - `standardrb`: roda `bundle exec standardrb` (falha o build em qualquer violação).
- Adiciona a gem `brakeman` no grupo `development, :test`.
- Roda `standardrb --fix` na base atual: strings double-quoted em `spec/swagger_helper.rb`, `Rails.root.join` idiomático no controller, e a migration `AddDefaultToCreatedAtAndUpdatedAt` ganha `:from`/`:to` para ser reversível.
- `config/database.yml` agora lê `DATABASE_HOST`, `DATABASE_USERNAME` e `DATABASE_PASSWORD` do ambiente (mantendo os defaults do `docker-compose`), para que o job de CI consiga apontar pro service do GitHub Actions.

## Como testar
1. Localmente:
```ruby
docker compose exec web bundle exec standardrb
docker compose exec web bundle exec brakeman --no-pager
docker compose exec web bundle exec rspec
```
Esperado: 0 violações no standardrb, 0 warnings no brakeman, 20/20 specs verdes.

2. CI: a aba "Checks" do PR vai mostrar 3 jobs verdes assim que o GitHub Actions processar.

## Riscos
Build pode falhar se alguma gem futura introduzir violação de estilo ou warning de segurança. É esse o ponto: o build vermelho vira sinal antes de mergear.

## Impactos negativos previstos
Pequeno aumento no tempo de cada PR por causa do CI.

## Instruções para deploy
Nenhuma instrução adicional. Só configuração de CI e gem de dev.

## Instruções para retorno
Rollback padrão desse PR.