### PR TITLE
le senha do postgres de um arquivo .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /coverage
+
+# Local env vars (use .env.example as template).
+/.env

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ API REST de catálogo de filmes. Importa filmes a partir de um arquivo CSV de fo
 
 ## Sobre
 
-O desafio original pedia dois endpoints — um para importar um CSV e outro para listar os filmes. Esta implementação adiciona:
+O desafio original pedia dois endpoints - um para importar um CSV e outro para listar os filmes. Esta implementação adiciona:
 
 - Importação **assíncrona** via SolidQueue. O `POST` retorna `202 Accepted` imediatamente com um `import_id` que pode ser consultado depois.
 - Endpoint de **status** (`GET /api/v1/movie_imports/:id`) para o cliente acompanhar a importação.
 - Stream do CSV com `CSV.foreach(headers: true)` em vez de carregar o arquivo inteiro em memória.
-- Importação envelopada em transaction — linha inválida no meio do arquivo dispara rollback completo.
+- Importação envelopada em transaction - linha inválida no meio do arquivo dispara rollback completo.
 - Índices em `title` (unique), `year`, `genre`, `country` e `published_at` para os filtros Ransack.
 - Documentação OpenAPI gerada via rswag em `/api-docs`.
 
@@ -38,25 +38,25 @@ O desafio original pedia dois endpoints — um para importar um CSV e outro para
 
 Copiar `.env.example` para `.env` e ajustar o `POSTGRES_PASSWORD`:
 
-```sh
+```ruby
 cp .env.example .env
 ```
 
 Buildar a imagem:
 
-```sh
+```ruby
 docker compose build
 ```
 
 Subir tudo (web + worker SolidQueue + Postgres):
 
-```sh
+```ruby
 docker compose up -d
 ```
 
 Criar e migrar o banco na primeira execução:
 
-```sh
+```ruby
 docker compose exec web bundle exec rails db:prepare
 ```
 
@@ -68,13 +68,13 @@ http://localhost:3001/api-docs
 
 Entrar no container web:
 
-```sh
+```ruby
 docker compose exec web bash
 ```
 
 ## Testes
 
-```sh
+```ruby
 docker compose exec web bundle exec rspec
 ```
 
@@ -95,7 +95,7 @@ Content-Type: multipart/form-data
 file=@netflix_titles.csv
 ```
 
-**Response — 202 Accepted**
+**Response - 202 Accepted**
 
 ```json
 {
@@ -104,7 +104,7 @@ file=@netflix_titles.csv
 }
 ```
 
-**Response — 400 Bad Request** (arquivo ausente)
+**Response - 400 Bad Request** (arquivo ausente)
 
 ```json
 {
@@ -123,7 +123,7 @@ s64,TV Show,13 Reasons Why,,"Dylan Minnette, ...",United States,"June 5, 2020",2
 
 Retorna o estado de uma importação. O status evolui por `processing → completed | failed | invalid_file`.
 
-**Response — 200 OK**
+**Response - 200 OK**
 
 ```json
 {
@@ -135,7 +135,7 @@ Retorna o estado de uma importação. O status evolui por `processing → comple
 }
 ```
 
-**Response — 404 Not Found**
+**Response - 404 Not Found**
 
 ```json
 {
@@ -149,14 +149,14 @@ Possíveis estados de `status`:
 |--------|-------------|
 | `processing` | job ainda na fila ou em execução |
 | `completed` | todos os registros foram inseridos |
-| `failed` | algum registro violou validação — rollback aplicado, `error_message` preenchido |
+| `failed` | algum registro violou validação - rollback aplicado, `error_message` preenchido |
 | `invalid_file` | content-type não era `text/csv` ou o arquivo estava vazio |
 
 ### GET /api/v1/movies
 
 Lista todos os filmes ordenados por `year asc` por padrão.
 
-**Response — 200 OK**
+**Response - 200 OK**
 
 ```json
 [
@@ -182,7 +182,7 @@ Quando nenhum filme é encontrado:
 
 Os filtros usam Ransack. Atributos permitidos: `title`, `genre`, `year`, `country`, `published_at`, `description`. Predicados Ransack (`_eq`, `_cont`, `_gteq`, …) são suportados.
 
-**Exemplo — filtro composto**
+**Exemplo - filtro composto**
 
 ```http
 GET /api/v1/movies?query[year_eq]=2020&query[country_eq]=Poland
@@ -208,7 +208,7 @@ GET /api/v1/movies?query[year_eq]=2020&query[country_eq]=Poland
 GET /api/v1/movies?query[s]=title+asc
 ```
 
-**Filtro inválido — 400 Bad Request**
+**Filtro inválido - 400 Bad Request**
 
 ```http
 GET /api/v1/movies?query[yer_eq]=2020

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ O desafio original pedia dois endpoints — um para importar um CSV e outro para
 
 ## Como usar
 
+Copiar `.env.example` para `.env` e ajustar o `POSTGRES_PASSWORD`:
+
+```sh
+cp .env.example .env
+```
+
 Buildar a imagem:
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
   web:
     tty: true
     stdin_open: true
@@ -14,6 +14,7 @@ services:
       - 1.1.1.1
     environment:
       - LANG=pt_BR.UTF-8
+      - DATABASE_PASSWORD=${POSTGRES_PASSWORD:-password}
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3001 -b '0.0.0.0'"
     volumes:
       - .:/myapp
@@ -29,6 +30,7 @@ services:
       - 1.1.1.1
     environment:
       - LANG=pt_BR.UTF-8
+      - DATABASE_PASSWORD=${POSTGRES_PASSWORD:-password}
     command: bundle exec rails solid_queue:start
     volumes:
       - .:/myapp


### PR DESCRIPTION
## O que mudou
Remove a senha do postgres hardcoded no `docker-compose.yml` e passa a lê-la de um arquivo `.env` local.

## Solução proposta
- `docker-compose.yml` agora usa `${POSTGRES_PASSWORD:-password}` nos services `db`, `web` e `worker`. O Docker Compose carrega automaticamente o arquivo `.env` da raiz do projeto.
- Adiciona `.env.example` como template (commitado) com `POSTGRES_PASSWORD=change_me`.
- Adiciona `.env` no `.gitignore` para que a senha real nunca entre no git.
- README atualizado com o passo `cp .env.example .env` antes do primeiro `docker compose up`.
- O default `:-password` mantém compatibilidade: quem clonar e esquecer do `.env` ainda consegue subir com o valor anterior.

## Como testar
1. Copia o exemplo:
```ruby
cp .env.example .env
```
2. Edita `.env` se quiser uma senha diferente. Para usar a senha do volume existente, deixe `POSTGRES_PASSWORD=password`.
3. Sobe a stack:
```ruby
docker compose down
docker compose up -d
```
4. Roda os testes:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 20/20 verdes.

## Riscos
Se alguém clonar o repo e esquecer de criar o `.env`, o postgres sobe com a senha default `password`. Aceitável em dev, ruim em prod.

## Impactos negativos previstos
Um passo extra no setup local.

## Instruções para deploy
Em produção, o `.env` (ou o mecanismo equivalente de injeção de env vars) precisa ter `POSTGRES_PASSWORD` setado para um valor forte.

## Instruções para retorno
Rollback padrão desse PR.