### PR TITLE
adiciona rate limit nas requisições da api com rack-attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.3.5"
 gem "rails", "~> 8.0.5"
 gem "pg", "~> 1.1"
 gem "solid_queue", "~> 1.1"
+gem "rack-attack", "~> 6.7"
 
 gem "puma", "~> 6.4"
 gem "rswag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -342,6 +344,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (~> 6.4)
+  rack-attack (~> 6.7)
   rails (~> 8.0.5)
   rails-i18n (~> 8.0)
   ransack

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,23 @@
+class Rack::Attack
+  IMPORT_LIMIT = 5
+  READ_LIMIT = 60
+  THROTTLE_WINDOW = 1.minute
+
+  throttle("imports/ip", limit: IMPORT_LIMIT, period: THROTTLE_WINDOW) do |req|
+    req.ip if req.post? && req.path == "/api/v1/movies"
+  end
+
+  throttle("api-read/ip", limit: READ_LIMIT, period: THROTTLE_WINDOW) do |req|
+    req.ip if req.get? && req.path.start_with?("/api/v1/")
+  end
+
+  self.throttled_responder = lambda do |req|
+    [
+      429,
+      {"Content-Type" => "application/json; charset=utf-8"},
+      [{error: I18n.t("messages.rate_limit.too_many_requests")}.to_json]
+    ]
+  end
+end
+
+Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new if Rails.env.test?

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -13,6 +13,8 @@ pt-BR:
     movies:
       not_found: "Nenhum filme encontrado"
       invalid_query_params: "Parâmetro de busca inválido"
+    rate_limit:
+      too_many_requests: "Muitas requisições. Por favor, tente novamente em alguns instantes."
   activerecord:
     errors:
       messages:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include ActiveJob::TestHelper
+
+  config.before(:each) { Rack::Attack.cache.store.clear }
 end
 
 def json_response

--- a/spec/requests/rate_limit_spec.rb
+++ b/spec/requests/rate_limit_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Rate limiting", type: :request do
+  before { Rack::Attack.cache.store.clear }
+
+  describe "POST /api/v1/movies" do
+    let(:file) { Rack::Test::UploadedFile.new("spec/fixtures/valid_file.csv", "text/csv") }
+
+    it "throttles after the import limit is exceeded" do
+      Rack::Attack::IMPORT_LIMIT.times do
+        post "/api/v1/movies", params: {file: file}
+        expect(response.status).not_to eq(429)
+      end
+
+      post "/api/v1/movies", params: {file: file}
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(JSON.parse(response.body)["error"]).to eq(I18n.t("messages.rate_limit.too_many_requests"))
+    end
+  end
+
+  describe "GET /api/v1/movies" do
+    it "throttles after the read limit is exceeded" do
+      Rack::Attack::READ_LIMIT.times do
+        get "/api/v1/movies"
+        expect(response.status).not_to eq(429)
+      end
+
+      get "/api/v1/movies"
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end


### PR DESCRIPTION
## O que mudou
Adiciona a gem `rack-attack` e dois throttles para proteger os endpoints da API contra abuso (DoS, scraping agressivo, brute force em filtros).

## Solução proposta
- Gem `rack-attack 6.7+` adicionada no `Gemfile`. O railtie da gem já injeta o middleware automaticamente.
- `config/initializers/rack_attack.rb` define dois throttles, ambos com chave por IP do cliente e janela de 1 minuto:
  - `imports/ip`: 5 `POST /api/v1/movies` por minuto.
  - `api-read/ip`: 60 `GET /api/v1/*` por minuto.
- Resposta 429 traz JSON em pt-BR com a mensagem `messages.rate_limit.too_many_requests`.
- No ambiente de teste, `Rack::Attack.cache.store` é um `ActiveSupport::Cache::MemoryStore` (o `:null_store` padrão do test não incrementaria contadores). Um `before(:each)` global limpa o store para que cada spec rode isolada.
- Specs novos em `spec/requests/rate_limit_spec.rb` validam o 429 nos dois throttles.

## Como testar
1. Sobe a stack:
```ruby
docker compose up -d
```
2. Roda os specs:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 22/22 verdes.

3. Faz uma rajada de POSTs (esperado: 6º responde 429):
```ruby
for i in 1 2 3 4 5 6; do
  docker compose exec web bash -c "curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:3001/api/v1/movies -F 'file=@./spec/fixtures/valid_file.csv;type=text/csv'"
done
```

4. Confirma standardrb + brakeman:
```ruby
docker compose exec web bundle exec standardrb
docker compose exec web bundle exec brakeman --no-pager --exit-on-warn
```

## Riscos
- Limites foram chutados (5 imports/min, 60 reads/min). Tunar com base em uso real.
- O store padrão é `Rails.cache`. Em produção, garantir que `Rails.cache` aponte para algo compartilhado (Redis/memcache) se houver mais de um processo web, caso contrário cada processo tem contadores próprios.

## Impactos negativos previstos
Cliente legítimo que faça rajada (ex: dashboard polling agressivo) pode bater no limite.

## Instruções para deploy
Garantir que `Rails.cache` esteja configurado para um backend compartilhado em produção.

## Instruções para retorno
Rollback padrão desse PR.