### PR TITLE
limita o tamanho do upload na importação de filmes

### DIFF
--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::MoviesController < ApplicationController
 
     if uploaded_file.size > MAX_UPLOAD_BYTES
       return render json: {
-        error: I18n.t("messages.import.too_large", limit_mb: MAX_UPLOAD_BYTES / 1.megabyte)
+        error: I18n.t("messages.import.too_large", limit: ActiveSupport::NumberHelper.number_to_human_size(MAX_UPLOAD_BYTES))
       }, status: :content_too_large
     end
 

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -1,12 +1,20 @@
 require "fileutils"
 
 class Api::V1::MoviesController < ApplicationController
+  MAX_UPLOAD_BYTES = 10.megabytes
+
   rescue_from ArgumentError, with: :invalid_param_message
 
   def create
     uploaded_file = params[:file]
     unless uploaded_file.respond_to?(:original_filename)
       return render json: {error: I18n.t("messages.import.missing_file")}, status: :bad_request
+    end
+
+    if uploaded_file.size > MAX_UPLOAD_BYTES
+      return render json: {
+        error: I18n.t("messages.import.too_large", limit_mb: MAX_UPLOAD_BYTES / 1.megabyte)
+      }, status: :content_too_large
     end
 
     import = MovieImport.create!(file_name: uploaded_file.original_filename, status: :processing)

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -9,7 +9,7 @@ pt-BR:
       create_error: "Erro ao criar filmes: %{error_message}"
       empty_file: "Arquivo vazio. Por favor, insira um arquivo com dados dos filmes."
       missing_file: "Arquivo não enviado. Por favor, anexe um arquivo CSV."
-      too_large: "Arquivo muito grande. Tamanho máximo permitido: %{limit_mb}MB."
+      too_large: "Arquivo muito grande. Tamanho máximo permitido: %{limit}."
       not_found: "Importação não encontrada."
     movies:
       not_found: "Nenhum filme encontrado"

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -9,6 +9,7 @@ pt-BR:
       create_error: "Erro ao criar filmes: %{error_message}"
       empty_file: "Arquivo vazio. Por favor, insira um arquivo com dados dos filmes."
       missing_file: "Arquivo não enviado. Por favor, anexe um arquivo CSV."
+      too_large: "Arquivo muito grande. Tamanho máximo permitido: %{limit_mb}MB."
       not_found: "Importação não encontrada."
     movies:
       not_found: "Nenhum filme encontrado"

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -141,6 +141,16 @@ RSpec.describe "Movies API", type: :request do
       expect(import.status).to eq("invalid_file")
       expect(import.error_message).to eq("Formato de arquivo inválido. Por favor, envie um arquivo CSV.")
     end
+
+    it "rejeita arquivo acima do limite com 413" do
+      stub_const("Api::V1::MoviesController::MAX_UPLOAD_BYTES", 100)
+
+      post "/api/v1/movies", params: {file: valid_csv}
+
+      expect(response).to have_http_status(:content_too_large)
+      expect(json_response["error"]).to include("Arquivo muito grande")
+      expect(MovieImport.count).to eq(0)
+    end
   end
 
   path "/api/v1/movie_imports/{id}" do

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -142,13 +142,14 @@ RSpec.describe "Movies API", type: :request do
       expect(import.error_message).to eq("Formato de arquivo inválido. Por favor, envie um arquivo CSV.")
     end
 
-    it "rejeita arquivo acima do limite com 413" do
+    it "rejeita arquivo que excede o limite e não cria o import" do
       stub_const("Api::V1::MoviesController::MAX_UPLOAD_BYTES", 100)
 
       post "/api/v1/movies", params: {file: valid_csv}
 
       expect(response).to have_http_status(:content_too_large)
-      expect(json_response["error"]).to include("Arquivo muito grande")
+      expect(json_response["error"]).to start_with("Arquivo muito grande")
+      expect(json_response["error"]).to include("100")
       expect(MovieImport.count).to eq(0)
     end
   end


### PR DESCRIPTION
## O que mudou
Coloca um teto de 10MB no upload do `POST /api/v1/movies`. Requisições acima do limite recebem `413 Content Too Large` antes de qualquer escrita em disco.

## Solução proposta
- Constante `MAX_UPLOAD_BYTES = 10.megabytes` em `Api::V1::MoviesController`.
- Check `uploaded_file.size > MAX_UPLOAD_BYTES` logo após a validação de presença do arquivo. Falha fast: nenhum `MovieImport` é criado nem nada é gravado em `tmp/imports/`.
- Resposta em pt-BR via `messages.import.too_large` com o limite interpolado.
- Spec usa `stub_const` para reduzir o limite a 100 bytes e dispara o 413 contra o fixture válido (~50KB).
- Status code novo `:content_too_large` (forma Rack 3+ que substitui o `:payload_too_large` deprecado).

## Como testar
1. Sobe a stack:
```ruby
docker compose up -d
```
2. Roda os specs:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 23/23 verdes.

3. Confirma standardrb e brakeman:
```ruby
docker compose exec web bundle exec standardrb
docker compose exec web bundle exec brakeman --no-pager --exit-on-warn
```

## Riscos
- 10MB foi chutado. Tunar se um CSV legítimo (catálogo Netflix completo, por exemplo) ultrapassar.
- Cliente legítimo enviando arquivo grande recebe rejeição sem orientação clara. A mensagem já traz o limite.

## Impactos negativos previstos
Uploads acima de 10MB passam a ser bloqueados em vez de enfileirados.

## Instruções para deploy
Nenhuma instrução adicional. Para limite diferente em produção, alterar `MAX_UPLOAD_BYTES` no controller (ou parametrizar via ENV em iteração futura).

## Instruções para retorno
Rollback padrão desse PR.