### PR TITLE
pagina o endpoint de listagem de filmes com pagy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 8.0.5"
 gem "pg", "~> 1.1"
 gem "solid_queue", "~> 1.1"
 gem "rack-attack", "~> 6.7"
+gem "pagy", "~> 9.0"
 
 gem "puma", "~> 6.4"
 gem "rswag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
+    pagy (9.4.0)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -341,6 +342,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   brakeman
   listen (~> 3.3)
+  pagy (~> 9.0)
   pg (~> 1.1)
   pry-byebug
   puma (~> 6.4)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,30 @@ Possíveis estados de `status`:
 
 ### GET /api/v1/movies
 
-Lista todos os filmes ordenados por `year asc` por padrão.
+Lista filmes ordenados por `year asc` por padrão, paginados via [pagy](https://github.com/ddnexus/pagy).
+
+**Paginação**
+
+| query param | default | máximo | descrição |
+|---|---|---|---|
+| `page` | 1 | - | número da página |
+| `limit` | 25 | 100 | tamanho da página |
+
+Cabeçalhos de resposta:
+
+| header | descrição |
+|---|---|
+| `Current-Page` | página atual |
+| `Total-Pages` | total de páginas |
+| `Total-Count` | total de registros |
+| `Page-Limit` | tamanho da página efetivo |
+| `Link` | RFC 5988 com `rel="next"`, `prev`, `first`, `last` |
+
+Exemplo:
+
+```ruby
+GET /api/v1/movies?page=2&limit=10
+```
 
 **Response - 200 OK**
 

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -31,11 +31,12 @@ class Api::V1::MoviesController < ApplicationController
     @query = Movie.all.ransack(params[:query])
     @query.sorts = "year asc" if @query.sorts.empty?
     @pagy, @movies = pagy(@query.result)
+    @movies = @movies.to_a
+    pagy_headers_merge(@pagy)
 
     if @movies.empty?
       render json: {message: I18n.t("messages.movies.not_found")}, status: :ok
     else
-      pagy_headers_merge(@pagy)
       render json: @movies.as_json(except: [:created_at, :updated_at]), status: :ok
     end
   end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -30,11 +30,12 @@ class Api::V1::MoviesController < ApplicationController
   def index
     @query = Movie.all.ransack(params[:query])
     @query.sorts = "year asc" if @query.sorts.empty?
-    @movies = @query.result
+    @pagy, @movies = pagy(@query.result)
 
     if @movies.empty?
       render json: {message: I18n.t("messages.movies.not_found")}, status: :ok
     else
+      pagy_headers_merge(@pagy)
       render json: @movies.as_json(except: [:created_at, :updated_at]), status: :ok
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include Pagy::Backend
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,15 @@
+require "pagy/extras/headers"
+require "pagy/extras/overflow"
+require "pagy/extras/limit"
+
+Pagy::DEFAULT[:limit] = 25
+Pagy::DEFAULT[:limit_max] = 100
+Pagy::DEFAULT[:limit_param] = :limit
+Pagy::DEFAULT[:limit_extra] = true
+Pagy::DEFAULT[:overflow] = :empty_page
+Pagy::DEFAULT[:headers] = {
+  page: "Current-Page",
+  pages: "Total-Pages",
+  count: "Total-Count",
+  limit: "Page-Limit"
+}

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -5,7 +5,6 @@ require "pagy/extras/limit"
 Pagy::DEFAULT[:limit] = 25
 Pagy::DEFAULT[:limit_max] = 100
 Pagy::DEFAULT[:limit_param] = :limit
-Pagy::DEFAULT[:limit_extra] = true
 Pagy::DEFAULT[:overflow] = :empty_page
 Pagy::DEFAULT[:headers] = {
   page: "Current-Page",

--- a/spec/requests/movies_pagination_spec.rb
+++ b/spec/requests/movies_pagination_spec.rb
@@ -56,5 +56,7 @@ RSpec.describe "GET /api/v1/movies pagination", type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(JSON.parse(response.body)).to eq("message" => "Nenhum filme encontrado")
+    expect(response.headers["Current-Page"]).to eq("99")
+    expect(response.headers["Total-Count"]).to eq("30")
   end
 end

--- a/spec/requests/movies_pagination_spec.rb
+++ b/spec/requests/movies_pagination_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/movies pagination", type: :request do
+  before do
+    30.times do |i|
+      Movie.create!(
+        title: "Movie #{i}",
+        genre: "Movie",
+        year: 2000 + i,
+        country: "USA",
+        published_at: "2020-01-01",
+        description: "Description #{i}"
+      )
+    end
+  end
+
+  it "returns the first page with the default limit and pagination headers" do
+    get "/api/v1/movies"
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).size).to eq(25)
+    expect(response.headers["Current-Page"]).to eq("1")
+    expect(response.headers["Total-Pages"]).to eq("2")
+    expect(response.headers["Total-Count"]).to eq("30")
+    expect(response.headers["Page-Limit"]).to eq("25")
+    expect(response.headers["Link"]).to include('rel="next"', 'rel="last"')
+  end
+
+  it "returns the requested page" do
+    get "/api/v1/movies", params: {page: 2}
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).size).to eq(5)
+    expect(response.headers["Current-Page"]).to eq("2")
+    expect(response.headers["Link"]).to include('rel="prev"', 'rel="first"')
+  end
+
+  it "honors the limit query parameter" do
+    get "/api/v1/movies", params: {limit: 10}
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).size).to eq(10)
+    expect(response.headers["Total-Pages"]).to eq("3")
+    expect(response.headers["Page-Limit"]).to eq("10")
+  end
+
+  it "caps the limit at the configured max" do
+    get "/api/v1/movies", params: {limit: 9999}
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers["Page-Limit"]).to eq("100")
+  end
+
+  it "returns the not-found message when a page beyond the last is requested" do
+    get "/api/v1/movies", params: {page: 99}
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to eq("message" => "Nenhum filme encontrado")
+  end
+end

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe "Movies API", type: :request do
       parameter name: :"query[published_at]", in: :query, type: :string, description: "Filtrar por data de publicação", required: false
       parameter name: :"query[description]", in: :query, type: :string, description: "Filtrar por descrição", required: false
       parameter name: :"query[invalid_param_eq]", in: :query, type: :string, description: "Filtro Inválido", required: false
+      parameter name: :page, in: :query, type: :integer, description: "Número da página (default 1)", required: false
+      parameter name: :limit, in: :query, type: :integer, description: "Itens por página (default 25, máximo 100)", required: false
 
       context "Quando há filmes correspondentes ao filtro" do
-        response "200", "retorna uma lista de filmes" do
+        response "200", "retorna uma lista paginada de filmes" do
           schema type: :array,
             items: {
               type: :object,
@@ -35,6 +37,12 @@ RSpec.describe "Movies API", type: :request do
               },
               required: ["title", "year", "genre", "published_at"]
             }
+
+          header "Current-Page", schema: {type: :string}, description: "Página atual"
+          header "Total-Pages", schema: {type: :string}, description: "Total de páginas"
+          header "Total-Count", schema: {type: :string}, description: "Total de registros"
+          header "Page-Limit", schema: {type: :string}, description: "Itens por página efetivo"
+          header "Link", schema: {type: :string}, description: "Links de navegação (RFC 5988)"
 
           let(:query) { {"query[country_eq]": "USA"} }
           run_test! do


### PR DESCRIPTION
## O que mudou
O `GET /api/v1/movies` agora pagina via [pagy](https://github.com/ddnexus/pagy). Antes retornava o catálogo inteiro em uma resposta única.

## Solução proposta
- Gem `pagy ~> 9.0` no `Gemfile`.
- `Pagy::Backend` incluído no `ApplicationController` para liberar o helper `pagy(...)` em qualquer action futura.
- `config/initializers/pagy.rb` configura os defaults globais:
  - `limit: 25` (tamanho default da página)
  - `limit_max: 100` (teto pra evitar `limit=99999`)
  - `limit_param: :limit` (lê do query string via extra `pagy/extras/limit`)
  - `overflow: :empty_page` (página depois da última retorna vazio em vez de explodir)
  - Headers customizados: `Current-Page`, `Total-Pages`, `Total-Count`, `Page-Limit` + `Link` (RFC 5988).
- `MoviesController#index` agora faz `@pagy, @movies = pagy(@query.result)` e chama `pagy_headers_merge(@pagy)` na resposta com registros.
- Spec novo `spec/requests/movies_pagination_spec.rb` cobre: default 25, página explícita, `limit` custom, cap em 100, overflow retorna 200 com `"Nenhum filme encontrado"`.
- README atualizado com tabela de query params e tabela de response headers.

## Como testar
1. Sobe a stack:
```ruby
docker compose up -d
```
2. Roda os specs:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 28/28 verdes.

3. Importa o CSV e bate no index:
```ruby
docker compose exec web bash -c "curl -X POST http://localhost:3001/api/v1/movies -F 'file=@./spec/fixtures/valid_file.csv;type=text/csv'"
sleep 5
docker compose exec web bash -c "curl -i 'http://localhost:3001/api/v1/movies?page=2&limit=10'"
```
Esperado: status 200, 10 itens no body, headers `Current-Page: 2`, `Total-Pages`, `Total-Count`, `Page-Limit: 10`, `Link` com `rel="prev"` e `rel="next"`.

## Riscos
- Mudança de contrato: clientes que pegavam a lista inteira agora recebem 25 por vez.
- Cap em 100 — cliente que pedir `limit=200` recebe `Page-Limit: 100` (sem erro, só silenciosamente cortado).

## Impactos negativos previstos
Cliente existente que não envia `page` ainda recebe primeira página (compatível). Cliente que precisa de tudo precisa iterar usando o header `Link`.

## Instruções para deploy
Nenhuma instrução adicional.

## Instruções para retorno
Rollback padrão desse PR.