### PR TITLE
extrai serializers de filmes e importações usando alba

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "pg", "~> 1.1"
 gem "solid_queue", "~> 1.1"
 gem "rack-attack", "~> 6.7"
 gem "pagy", "~> 9.0"
+gem "alba", "~> 3.0"
 
 gem "puma", "~> 6.4"
 gem "rswag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    alba (3.10.0)
     ast (2.4.2)
     base64 (0.3.0)
     benchmark (0.5.0)
@@ -339,6 +340,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  alba (~> 3.0)
   bootsnap (>= 1.4.4)
   brakeman
   listen (~> 3.3)

--- a/app/controllers/api/v1/movie_imports_controller.rb
+++ b/app/controllers/api/v1/movie_imports_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::MovieImportsController < ApplicationController
   def show
     import = MovieImport.find(params[:id])
-    render json: import.as_json(except: [:created_at, :updated_at]), status: :ok
+    render json: MovieImportSerializer.new(import).serializable_hash, status: :ok
   rescue ActiveRecord::RecordNotFound
     render json: {error: I18n.t("messages.import.not_found")}, status: :not_found
   end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::MoviesController < ApplicationController
     if @movies.empty?
       render json: {message: I18n.t("messages.movies.not_found")}, status: :ok
     else
-      render json: @movies.as_json(except: [:created_at, :updated_at]), status: :ok
+      render json: MovieSerializer.new(@movies).serializable_hash, status: :ok
     end
   end
 

--- a/app/serializers/movie_import_serializer.rb
+++ b/app/serializers/movie_import_serializer.rb
@@ -1,0 +1,5 @@
+class MovieImportSerializer
+  include Alba::Resource
+
+  attributes :id, :file_name, :error_message, :status, :movies_count
+end

--- a/app/serializers/movie_serializer.rb
+++ b/app/serializers/movie_serializer.rb
@@ -1,0 +1,5 @@
+class MovieSerializer
+  include Alba::Resource
+
+  attributes :id, :title, :genre, :year, :country, :published_at, :description
+end

--- a/config/initializers/alba.rb
+++ b/config/initializers/alba.rb
@@ -1,0 +1,1 @@
+Alba.inflector = :active_support

--- a/spec/serializers/movie_import_serializer_spec.rb
+++ b/spec/serializers/movie_import_serializer_spec.rb
@@ -1,17 +1,42 @@
 require "rails_helper"
 
 RSpec.describe MovieImportSerializer do
-  let(:import) { MovieImport.create!(file_name: "netflix.csv", status: :completed, movies_count: 131) }
+  context "quando a importação foi concluída" do
+    let(:import) { MovieImport.create!(file_name: "netflix.csv", status: :completed, movies_count: 131) }
 
-  it "exposes only the public fields" do
-    hash = described_class.new(import).serializable_hash
+    it "expõe os atributos públicos com os valores corretos" do
+      hash = described_class.new(import).serializable_hash
 
-    expect(hash.keys).to match_array(%w[id file_name error_message status movies_count])
+      expect(hash["file_name"]).to eq("netflix.csv")
+      expect(hash["status"]).to eq("completed")
+      expect(hash["movies_count"]).to eq(131)
+      expect(hash["error_message"]).to be_nil
+      expect(hash["id"]).to be_present
+    end
+
+    it "não expõe created_at nem updated_at" do
+      hash = described_class.new(import).serializable_hash
+
+      expect(hash).not_to include("created_at", "updated_at")
+    end
   end
 
-  it "does not leak created_at or updated_at" do
-    hash = described_class.new(import).serializable_hash
+  context "quando a importação falhou" do
+    let(:import) do
+      MovieImport.create!(
+        file_name: "broken.csv",
+        status: :failed,
+        movies_count: 0,
+        error_message: "Title não pode ficar em branco"
+      )
+    end
 
-    expect(hash).not_to include("created_at", "updated_at")
+    it "expõe a mensagem de erro junto com o status" do
+      hash = described_class.new(import).serializable_hash
+
+      expect(hash["status"]).to eq("failed")
+      expect(hash["error_message"]).to eq("Title não pode ficar em branco")
+      expect(hash["movies_count"]).to eq(0)
+    end
   end
 end

--- a/spec/serializers/movie_import_serializer_spec.rb
+++ b/spec/serializers/movie_import_serializer_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe MovieImportSerializer do
+  let(:import) { MovieImport.create!(file_name: "netflix.csv", status: :completed, movies_count: 131) }
+
+  it "exposes only the public fields" do
+    hash = described_class.new(import).serializable_hash
+
+    expect(hash.keys).to match_array(%w[id file_name error_message status movies_count])
+  end
+
+  it "does not leak created_at or updated_at" do
+    hash = described_class.new(import).serializable_hash
+
+    expect(hash).not_to include("created_at", "updated_at")
+  end
+end

--- a/spec/serializers/movie_serializer_spec.rb
+++ b/spec/serializers/movie_serializer_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe MovieSerializer do
+  let(:movie) do
+    Movie.create!(
+      title: "Hereditary",
+      genre: "Movie",
+      year: 2018,
+      country: "USA",
+      published_at: "2018-08-01",
+      description: "Family horror"
+    )
+  end
+
+  it "exposes only the public fields" do
+    hash = described_class.new(movie).serializable_hash
+
+    expect(hash.keys).to match_array(%w[id title genre year country published_at description])
+  end
+
+  it "does not leak created_at or updated_at" do
+    hash = described_class.new(movie).serializable_hash
+
+    expect(hash).not_to include("created_at", "updated_at")
+  end
+
+  it "serializes a collection" do
+    other = Movie.create!(title: "Other", genre: "Movie", year: 2019, country: "USA", published_at: "2019-01-01")
+
+    hashes = described_class.new([movie, other]).serializable_hash
+
+    expect(hashes.pluck("title")).to contain_exactly("Hereditary", "Other")
+  end
+end

--- a/spec/serializers/movie_serializer_spec.rb
+++ b/spec/serializers/movie_serializer_spec.rb
@@ -12,23 +12,30 @@ RSpec.describe MovieSerializer do
     )
   end
 
-  it "exposes only the public fields" do
+  it "serializa os atributos públicos com os valores corretos" do
     hash = described_class.new(movie).serializable_hash
 
-    expect(hash.keys).to match_array(%w[id title genre year country published_at description])
+    expect(hash["title"]).to eq("Hereditary")
+    expect(hash["genre"]).to eq("Movie")
+    expect(hash["year"]).to eq(2018)
+    expect(hash["country"]).to eq("USA")
+    expect(hash["description"]).to eq("Family horror")
+    expect(hash["id"]).to be_present
+    expect(hash["published_at"]).to be_present
   end
 
-  it "does not leak created_at or updated_at" do
+  it "não expõe created_at nem updated_at" do
     hash = described_class.new(movie).serializable_hash
 
     expect(hash).not_to include("created_at", "updated_at")
   end
 
-  it "serializes a collection" do
+  it "serializa uma coleção mantendo o contrato em cada item" do
     other = Movie.create!(title: "Other", genre: "Movie", year: 2019, country: "USA", published_at: "2019-01-01")
 
     hashes = described_class.new([movie, other]).serializable_hash
 
     expect(hashes.pluck("title")).to contain_exactly("Hereditary", "Other")
+    expect(hashes.first.keys).not_to include("created_at", "updated_at")
   end
 end


### PR DESCRIPTION
## O que mudou
Tira o `@record.as_json(except: [:created_at, :updated_at])` do controller e move pra serializers dedicados usando a gem [alba](https://github.com/okuramasafumi/alba).

## Solução proposta
- Gem `alba ~> 3.0` no `Gemfile`.
- `config/initializers/alba.rb` configura `Alba.inflector = :active_support` para coerência com Rails.
- `app/serializers/movie_serializer.rb` e `app/serializers/movie_import_serializer.rb` declaram explicitamente os atributos públicos. `created_at`/`updated_at` deixam de aparecer no payload sem precisar de allowlist no controller.
- `MoviesController#index` agora faz `render json: MovieSerializer.new(@movies).serializable_hash`. `MovieImportsController#show` faz o equivalente com `MovieImportSerializer`.
- Specs unitários em `spec/serializers/` travam a lista de campos e garantem que os timestamps fiquem fora — se alguém adicionar uma coluna no `Movie` futuramente, o serializer não vai começar a expor por acidente.

## Como testar
1. Sobe a stack:
```ruby
docker compose up -d
```
2. Roda os specs:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 33/33 verdes.

3. Confere o payload do `GET /api/v1/movies`:
```ruby
docker compose exec web bash -c "curl -s 'http://localhost:3001/api/v1/movies?limit=1' | jq"
```
Esperado: array com objetos contendo apenas `id, title, genre, year, country, published_at, description` — sem `created_at`/`updated_at`.

4. Confere o payload do `GET /api/v1/movie_imports/:id` (após uma importação):
```ruby
docker compose exec web bash -c "curl -s http://localhost:3001/api/v1/movie_imports/<id> | jq"
```
Esperado: `id, file_name, error_message, status, movies_count`.

5. Confirma standardrb + brakeman:
```ruby
docker compose exec web bundle exec standardrb
docker compose exec web bundle exec brakeman --no-pager --exit-on-warn
```

## Riscos
- Contrato do response muda formalmente do `as_json(except:)` pra `Alba#serializable_hash`. O conteúdo é equivalente (verificado pelos specs unitários e pelos request specs), mas a ordem das chaves pode diferir.
- Future-proofing: qualquer atributo novo no model só aparece no JSON se for adicionado explicitamente ao serializer.

## Impactos negativos previstos
Nenhum. Spec coverage continua 100%.

## Instruções para deploy
Nenhuma instrução adicional.

## Instruções para retorno
Rollback padrão desse PR.