### PR TITLE
move gem ransack para o escopo de runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "solid_queue", "~> 1.1"
 gem "rack-attack", "~> 6.7"
 gem "pagy", "~> 9.0"
 gem "alba", "~> 3.0"
+gem "ransack"
 
 gem "puma", "~> 6.4"
 gem "rswag"
@@ -21,7 +22,6 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails", "~> 7.1"
   gem "ruby-lsp"
-  gem "ransack"
 end
 
 group :development do


### PR DESCRIPTION
## O que mudou
Move a gem `ransack` de `group :development, :test` para o escopo runtime no `Gemfile`.

## Solução proposta
`MoviesController#index` chama `Movie.all.ransack(params[:query])` em produção. Com a gem isolada nos grupos `:development, :test`, o primeiro request ao endpoint dispara `LoadError: cannot load such file -- ransack` e retorna 500 para todos os clientes.

Mudança de 1 linha: ransack agora fica junto com `rails`, `pagy`, `alba`, etc.

## Como testar
1. Sobe a stack:
```ruby
docker compose up -d
```
2. Roda os testes:
```ruby
docker compose exec web bundle exec rspec
```
Esperado: 34/34 verdes.

3. Verifica que ransack está disponível em produção simulando o ambiente:
```ruby
docker compose exec web bash -c "RAILS_ENV=production bundle exec rails runner 'puts Movie.respond_to?(:ransack)'"
```
Esperado: `true`.

## Riscos
Nenhum. ransack já era carregado em dev/test, agora carrega em prod também.

## Impactos negativos previstos
Aumento marginal no boot time em produção (1 gem a mais).

## Instruções para deploy
Rodar `bundle install` no deploy.

## Instruções para retorno
Rollback padrão desse PR.